### PR TITLE
Update section headers for clarity and consistency

### DIFF
--- a/src/common/index.ejs
+++ b/src/common/index.ejs
@@ -9,12 +9,12 @@
 <% } %>
 
 <div class="container-lg mx-auto py-8">
-    <h2 class="text-3xl font-bold text-left">PAT</h2>
+    <h2 class="text-3xl font-bold text-left">Private Advertising</h2>
     <div class="grid grid-cols-1  md:grid-cols-4 gap-6 mb-8 mt-8 w-full md:w-[60rem] mx-auto max-w-80 md:max-w-full">
         <%= renderCard('Privacy Sandcastle', '🔒', 'https://psat-pat-demos-home.dev/') %>
         <%= renderCard('Casale Media Demo', '🛡️', 'https://privacysandboxdemos.domain-aaa.com/') %>
     </div>
-    <h2 class="text-3xl font-bold text-left">PPE</h2>
+    <h2 class="text-3xl font-bold text-left">Site Boundaries</h2>
     <div class="grid grid-cols-1  md:grid-cols-4 gap-6 mb-8 mt-8 w-full md:w-[60rem] mx-auto max-w-80 md:max-w-full">
         <%= renderCard('Analytics Tracking', '🔎', '/analytics') %>
         <%= renderCard('Embedded Content', '📽️', '/embedded-video') %>


### PR DESCRIPTION
### Description

- Renamed the "PAT" section to "Private Advertising" for improved clarity.
- Renamed the "PPE" section to "Site Boundaries" to better reflect its contents.

These changes enhance readability and ensure section headers are more descriptive of the content they outline.